### PR TITLE
fix: remove Go setup from CI, update checkout to v5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,11 +16,8 @@ jobs:
     name: pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: actions/setup-go@v5
-        with:
-          go-version: stable
       - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Go setup was unnecessary (actionlint is pre-built) and caused cache warnings. Bump actions/checkout to v5 for Node.js 24 compatibility.