### PR TITLE
ci: run lint on release-please branches to unblock PR merge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - release-please--**
   pull_request:
     branches:
       - main


### PR DESCRIPTION
GitHub Actions does not fire pull_request events for PRs opened by GITHUB_TOKEN, so the pre-commit check never ran on release-please PRs. Triggering on push to release-please--** satisfies the required status check on the PR's head commit.