### PR TITLE
ci: exclude CHANGELOG.md from markdownlint

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
CHANGELOG.md is auto-generated by release-please and contains double blank lines between sections (MD012) that markdownlint --fix rewrites in CI but cannot commit back, causing the lint check to fail.