### PR TITLE
ci: use pull_request_target so lint runs once on bot PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,10 @@ on:
   push:
     branches:
       - main
-      - release-please--**
-  pull_request:
+  pull_request_target:
     branches:
       - main
+    types: [opened, synchronize, reopened]
 
 name: Lint
 
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,14 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+      - release-please--**
+  pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: lint-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
 
 name: Lint
 
@@ -18,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"


### PR DESCRIPTION
pull_request events are not fired for PRs created by GITHUB_TOKEN, causing the check to stall as "waiting for status". pull_request_target fires for all PRs including bot-created ones; the explicit ref checkout ensures the PR head is linted, not the base branch.

Drops the release-please--** push workaround that caused duplicate runs.