### PR TITLE
fix(purge): fix --purge-old aborting under pipefail and without tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ AMD Zen 4 (Ryzen 9 7950X3D), NVIDIA GPU, Linux Mint 22.3.
 See `fragments/cpu-amd-zen4.config` and `fragments/hardware-desktop.config` for
 the full hardware profile.
 
+## udev Rules
+
+The `udev/` directory contains rules that must be installed once on the target system:
+
+```bash
+sudo cp udev/60-ioscheduler.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+This assigns **Kyber** to NVMe devices and **BFQ** to rotational HDDs at boot.
+
 ## Firmware
 
 The Realtek RTL8125 NIC (r8169 driver) requires firmware files not yet
@@ -101,7 +112,7 @@ Additional commands:
 - **Memory:** THP with MADVISE, Multi-Gen LRU, PER_VMA_LOCK, NUMA balancing
 - **Swap:** zswap with zstd compressor (default on)
 - **Network:** BBR congestion control, FQ/FQ_CODEL/CAKE qdisc
-- **I/O:** mq-deadline default (NVMe), BFQ available for rotational devices
+- **I/O:** Kyber for NVMe, BFQ for rotational HDDs (assigned at runtime via udev)
 - **Modules:** zstd compression
 - **Security:** AppArmor (Mint default), no SELinux
 - **Debug:** All tracing, kprobes, BTF, DWARF, KASAN, etc. disabled
@@ -143,7 +154,7 @@ related options so only the relevant files need to change when hardware changes.
 | `gpu-nvidia.config` | RTX 3070: DRM core + SimpleDRM; disables nouveau, AMD GPU, Intel GPU |
 | `sound-realtek.config` | HDA Intel + Realtek ALC4080; disables unused HDA codecs, HDMI audio, AMD APU audio, Intel SOC audio |
 | `network-realtek.config` | RTL8125 2.5GbE, Bluetooth; disables WiFi, all other NIC vendors, legacy USB network adapters; BBR/FQ/Cake |
-| `storage.config` | NVMe, SATA, SCSI, BFQ scheduler, filesystems; disables PATA, unused SATA controllers, exotic FS, enterprise HBA/FCoE |
+| `storage.config` | NVMe, SATA, SCSI, Kyber + BFQ schedulers, filesystems; disables PATA, unused SATA controllers, exotic FS, enterprise HBA/FCoE |
 | `hardware-desktop.config` | USB, HID, SD card readers, UVC webcam, watchdog off, no-AMD crypto accelerators, VFIO; disables laptop touchpad drivers and PCIe card readers |
 
 Fragments are applied in the order listed; later fragments take precedence on

--- a/buildKernel.sh
+++ b/buildKernel.sh
@@ -90,8 +90,8 @@ fi
 # --- Purge old kernels -------------------------------------------------------
 if [[ "${1:-}" == "--purge-old" ]]; then
   lb="$(whoami)-$(hostname -s)"
-  dpkg -l "linux-image-*-${lb}*" 2>/dev/null | awk '/^ii/{print $2}' | sort -V | head -n -2 \
-    | sed -n 'p;s/linux-image-/linux-headers-/p' | xargs -r sudo apt-get purge
+  { dpkg -l "linux-image-*-${lb}*" 2>/dev/null || true; } | awk '/^ii/{print $2}' | sort -V | head -n -2 \
+    | sed -n 'p;s/linux-image-/linux-headers-/p' | xargs -r sudo apt-get purge -y
   sudo apt-get autoremove -y && success "Done."; exit 0
 fi
 

--- a/fragments/base.config
+++ b/fragments/base.config
@@ -64,6 +64,7 @@ CONFIG_LRU_GEN_ENABLED=y
 # --- Preemption (dynamic = best of both worlds on desktop) ------------------
 CONFIG_PREEMPT=y
 CONFIG_PREEMPT_DYNAMIC=y
+# CONFIG_PREEMPT_LAZY is not set
 # CONFIG_PREEMPT_VOLUNTARY is not set
 # CONFIG_PREEMPT_NONE is not set
 

--- a/fragments/storage.config
+++ b/fragments/storage.config
@@ -25,9 +25,10 @@ CONFIG_SCSI=y
 CONFIG_BLK_DEV_SD=y
 CONFIG_BLK_DEV_SR=y
 
-# --- I/O scheduler: BFQ for desktop mixed workloads -------------------------
-# Note: CONFIG_DEFAULT_IOSCHED was removed in 6.18; BFQ is assigned to
-# rotational devices at runtime via udev.
+# --- I/O scheduler -----------------------------------------------------------
+# Note: CONFIG_DEFAULT_IOSCHED was removed in 6.18; schedulers are assigned
+# at runtime via udev: Kyber → NVMe/fast SSDs, BFQ → rotational HDDs.
+CONFIG_MQ_IOSCHED_KYBER=y
 CONFIG_MQ_IOSCHED_DEADLINE=y
 CONFIG_IOSCHED_BFQ=y
 CONFIG_BFQ_GROUP_IOSCHED=y

--- a/udev/60-ioscheduler.rules
+++ b/udev/60-ioscheduler.rules
@@ -1,0 +1,5 @@
+# I/O scheduler assignment
+# NVMe: Kyber (low-latency, two-queue scheduler designed for fast SSDs)
+ACTION=="add|change", KERNEL=="nvme[0-9]n[0-9]", ATTR{queue/scheduler}="kyber"
+# HDDs: BFQ (fair queuing with per-process I/O budget)
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq"


### PR DESCRIPTION
dpkg -l exits 1 when no packages match, causing the pipeline to fail under set -euo pipefail; also xargs-launched apt-get had no tty for the confirmation prompt. Wrap dpkg in { ... || true; } and add -y to apt-get purge.

Also enables CONFIG_MQ_IOSCHED_KYBER and updates docs to reflect Kyber (NVMe) + BFQ (HDD) scheduler assignment via udev.