### PR TITLE
fix(lint): re-add push trigger for release-please branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - release-please--branches--main
 
 name: Lint
 


### PR DESCRIPTION
PRs created by github-actions[bot] via GITHUB_TOKEN do not trigger on: pull_request workflows. Add an explicit push trigger on the release-please branch so the pre-commit check runs and can report its status.