### PR TITLE
fix(ci): use PAT for release-please to allow workflow triggers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - release-please--branches--main
 
 name: Lint
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
GITHUB_TOKEN suppresses workflow runs on its own push/PR events. Switching to a PAT means release-please's PRs and pushes appear as a real user, allowing the lint workflow to trigger normally.

Also reverts the ineffective push trigger added to lint.yml.