### PR TITLE
fix(sound,gpu): pin new AMDGPU/sound options from diff review

### DIFF
--- a/fragments/gpu-amd.config
+++ b/fragments/gpu-amd.config
@@ -23,9 +23,16 @@ CONFIG_DRM_AMDGPU=m
 # CONFIG_DRM_AMDGPU_SI is not set
 # CONFIG_DRM_RADEON is not set
 
+# --- Disable unused AMDGPU sub-features -------------------------------------
+# CONFIG_DRM_AMDGPU_WERROR is not set
+# CONFIG_DRM_AMD_ACP is not set
+# CONFIG_DRM_AMD_ISP is not set
+# CONFIG_DRM_AMD_SECURE_DISPLAY is not set
+
 # --- ROCm / HIP compute (HSA_AMD auto-enables DRM_AMDGPU_USERPTR) ------------
 CONFIG_HSA_AMD=y
 CONFIG_HSA_AMD_SVM=y
+# CONFIG_HSA_AMD_P2P is not set
 
 # --- Disable NVIDIA drivers --------------------------------------------------
 # CONFIG_DRM_NOUVEAU is not set

--- a/fragments/sound-hdmi.config
+++ b/fragments/sound-hdmi.config
@@ -6,6 +6,7 @@
 #   Comment out this file to disable all display audio.
 # ==============================================================================
 
+CONFIG_SND_HDA_COMPONENT=y
 CONFIG_SND_HDA_CODEC_HDMI=m
 # CONFIG_SND_HDA_CODEC_HDMI_SIMPLE is not set
 # CONFIG_SND_HDA_CODEC_HDMI_INTEL is not set

--- a/fragments/sound-realtek.config
+++ b/fragments/sound-realtek.config
@@ -40,11 +40,16 @@ CONFIG_SND_USB_AUDIO=m
 # CONFIG_SND_USB_US144MKII is not set
 # CONFIG_SND_USB_6FIRE is not set
 # CONFIG_SND_USB_HIFACE is not set
-# CONFIG_SND_USB_LINE6 is not set
 
 # --- Disable entire Intel SOC audio stack (not needed on AMD) ----------------
 # CONFIG_SND_SOC_INTEL_SST_TOPLEVEL is not set
+# CONFIG_SND_SOC_INTEL_EHL_RT5660_MACH is not set
+# CONFIG_SND_SOC_INTEL_SKL_HDA_DSP_GENERIC_MACH is not set
 # CONFIG_SND_SOC_INTEL_SOF_DA7219_MACH is not set
+# CONFIG_SND_SOC_INTEL_SOF_CS42L42_MACH is not set
+# CONFIG_SND_SOC_INTEL_SOF_ES8336_MACH is not set
+# CONFIG_SND_SOC_INTEL_SOF_NAU8825_MACH is not set
+# CONFIG_SND_SOC_INTEL_SOF_PCM512x_MACH is not set
 
 # --- Disable AMD APU audio (7950X3D is CPU-only, no integrated audio) --------
 # CONFIG_SND_SOC_AMD_ACP3x is not set


### PR DESCRIPTION
- sound-hdmi: add SND_HDA_COMPONENT=y (HDA–GPU binding for HDMI audio)
- gpu-amd: disable unused sub-features (ACP, ISP, SECURE_DISPLAY, WERROR, P2P) to prevent future olddefconfig flips
- sound-realtek: disable new Intel SOF machine drivers that appeared as n in the diff; explicit to guard against future defaults
- sound-realtek: drop ineffective SND_USB_LINE6 disable