### PR TITLE
ci: add check-json and gitleaks hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,8 @@ repos:
         args: ["--branch", "main"]
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: check-json
+        exclude: ^\.vscode/
       - id: check-yaml
       - id: check-added-large-files
         args: ["--maxkb=1024"]
@@ -46,3 +48,8 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.27.2
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
- check-json: validates JSON files; .vscode/ excluded (JSONC with comments)
- gitleaks: secrets detection for public repo hardening